### PR TITLE
just set the hash to the hash - not the whole location

### DIFF
--- a/jquery.localScroll.js
+++ b/jquery.localScroll.js
@@ -93,7 +93,7 @@
 
 			elem[attr] = '';
 			$('body').prepend($a);
-			location = link.hash;
+			location.hash = link.hash;
 			$a.remove();
 			elem[attr] = id;
 		}


### PR DESCRIPTION
Fix `hash:true` on pages that use a base URI that isn't the same as the page URI.
