### PR TITLE
require jQuery as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"demo": "http://demos.flesler.com/jquery/localScroll",
 	"keywords": ["browser","animated","animation","scrolling","scroll","links","anchors","jquery-plugin","ecosystem:jquery"],
 	"ignore": ["**/.*","demo","tests","CHANGELOG","README.md","bower.json"],
-	"dependencies": {
+	"peerDependencies": {
 		"jquery": ">=1.8",
 		"jquery.scrollto": ">=2.0.0"
 	}


### PR DESCRIPTION
You should load your host jQuery as a peerDependency: https://nodejs.org/en/blog/npm/peer-dependencies/#the-problem-plugins
