### PR TITLE
Add option to disable scrolling on page load

### DIFF
--- a/jquery.localScroll.js
+++ b/jquery.localScroll.js
@@ -28,7 +28,8 @@
 		axis: 'y', // Which of top and left should be modified.
 		event: 'click', // On which event to react.
 		stop: true, // Avoid queuing animations 
-		target: window // What to scroll (selector or element). The whole window by default.
+		target: window, // What to scroll (selector or element). The whole window by default.
+		autoscroll: true // If true, applies the scrolling at initial page load.
 		/*
 		lock: false, // ignore events if already animating
 		lazy: false, // if true, links can be added later, and will still work.
@@ -41,7 +42,7 @@
 	$.fn.localScroll = function(settings) {
 		settings = $.extend({}, $localScroll.defaults, settings);
 
-		if (settings.hash && location.hash) {
+		if (settings.autoscroll && settings.hash && location.hash) {
 			if (settings.target) window.scrollTo(0, 0);
 			scroll(0, location, settings);
 		}


### PR DESCRIPTION
This is following discussion in #32. Minified version built with Packer as mentioned in the thread.

I know you were not in favor of an option for this, but I had to come up with this for my own consumption until this is doable with the upstream version of the library (to be able to replace [my outdated copy](https://github.com/astorije/jeremie.astori.fr/blob/b69664c89405cae4842999748d73e66b0c23d86b/public_html/js/jquery.localscroll.min.js) while keeping the existing behavior). I figured I would make my changes available if anyone is interested as well in the future.

I would prefer not to monkey-patch a fork but I totally understand and respect your preferences, I did not intend to make a push for this PR to be merged. Feel free to close it or suggest improvements regardless of your decision 😃
Thanks!