### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install jquery.localscroll
 
 CDN provided by [jsdelivr](http://www.jsdelivr.com/#!jquery.localscroll)
 ```html
-<script src="//cdn.jsdelivr.net/jquery.localscroll/1.4.0/jquery.localScroll.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/jquery.localscroll@2.0.0/jquery.localScroll.min.js"></script>
 ```
 CDN provided by [cdnjs](https://cdnjs.com/libraries/jquery-localScroll) (outdated)
 ```html


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jquery.localscroll.

Feel free to ping me if you have any questions regarding this change.